### PR TITLE
dynamic NS-entry config and https support

### DIFF
--- a/includes/config.inc.php-dist
+++ b/includes/config.inc.php-dist
@@ -6,6 +6,7 @@ $apiip   = '';          # The IP of the PowerDNS API
 $apiport = '8081';      # The port of the PowerDNS API
 $apisid  = 'localhost'; # PowerDNS's :server_id
 $allowzoneadd = FALSE;  # Allow normal users to add zones
+$apiprotocol = 'http://'; # protocol used to connect with trailing slashs
 
 ### AUTHENTICATION ###
 # The first versions of the PowerDNS API used the standard webserver password
@@ -48,7 +49,7 @@ $templates[] = array(
 $defaults['soa_edit']    = 'INCEPTION-INCREMENT';
 $defaults['soa_edit_api'] = 'INCEPTION-INCREMENT';
 $defaults['defaulttype'] = 'Master';                    # Choose between 'Native' or 'Master'
-$defaults['primaryns']   = 'unconfigured.primaryns';    # The value of the first NS-record
-$defaults['secondaryns'] = 'unconfigured.secondaryns';  # The value of the second NS-record
+$defaults['ns'][0]   = 'unconfigured.primaryns';    # The value of the first NS-record
+$defaults['ns'][1] = 'unconfigured.secondaryns';  # The value of the second NS-record
 $defaults['ttl']         = 3600;                        # Default TTL for records
 $defaults['priority']    = 0;                           # Default for priority in records

--- a/index.php
+++ b/index.php
@@ -443,22 +443,20 @@ $(document).ready(function () {
                 edit: false,
                 inputClass: 'template'
             },
-            nameserver1: {
-                title: 'Pri. Nameserver',
+            <?php
+            $i = 1;
+            foreach($defaults['ns'] as $ns) {
+              echo "nameserver".$i.": {
+                title: '".($i == 1 ? 'Pri.' : 'Sec.')." Nameserver',
                 create: true,
                 list: false,
                 edit: false,
-                defaultValue: '<?php echo $defaults['primaryns']; ?>',
-                inputClass: 'nameserver nameserver1'
-            },
-            nameserver2: {
-                title: 'Sec. Nameserver',
-                create: true,
-                list: false,
-                edit: false,
-                defaultValue: '<?php echo $defaults['secondaryns']; ?>',
-                inputClass: 'nameserver nameserver2'
-            },
+                defaultValue: '".$ns."',
+                inputClass: 'nameserver nameserver".$i."'
+              },\n\t\t\t";
+              $i++;
+            }
+            ?>
             serial: {
                 title: 'Serial',
                 width: '10%',

--- a/zones.php
+++ b/zones.php
@@ -11,14 +11,14 @@ if (!is_csrf_safe()) {
 }
 
 function api_request($path, $opts = null, $type = null) {
-    global $apisid, $apiuser, $apipass, $apiip, $apiport, $authmethod;
+    global $apisid, $apiuser, $apipass, $apiip, $apiport, $authmethod, $apiprotocol;
 
-    $url = "http://$apiip:$apiport${path}";
+    $url = $apiprotocol."$apiip:$apiport${path}";
 
     if ($authmethod == "auto") {
         $ad = curl_init();
         curl_setopt($ad, CURLOPT_HTTPHEADER, array('X-API-Key: '.$apipass));
-        curl_setopt($ad, CURLOPT_URL, "http://$apiip:$apiport/servers/localhost/statistics");
+        curl_setopt($ad, CURLOPT_URL, $apiprotocol."$apiip:$apiport/servers/localhost/statistics");
         curl_setopt($ad, CURLOPT_RETURNTRANSFER, 1);
         curl_exec($ad);
         if (curl_getinfo($ad, CURLINFO_HTTP_CODE) == 401) {
@@ -452,11 +452,12 @@ case "create":
         );
 
     $nameservers = array();
-    if (isset($_POST['nameserver1']) && $_POST['nameserver1'] != null) {
-        array_push($nameservers, $_POST['nameserver1']);
-    }
-    if (isset($_POST['nameserver2']) && $_POST['nameserver2'] != null) {
-        array_push($nameservers, $_POST['nameserver2']);
+    $i = 1;
+    while(isset($_POST['nameserver'.$i])) {
+        if(!empty($_POST['nameserver'.$i])) {
+            array_push($nameservers, $_POST['nameserver'.$i]);
+        }
+        $i++;
     }
 
     if ($zonekind != "Slave") {


### PR DESCRIPTION
Hello,

sorry for the last stupid commit, it was to late at night.

I added the abbility to insert multiple dns-servers for NS-field generation for setups with 3 or more nameserver.
I also added a config-parameter to call the API via https.