### PR TITLE
add VERFIYPEER option to main api-request

### DIFF
--- a/zones.php
+++ b/zones.php
@@ -41,6 +41,9 @@ function api_request($path, $opts = null, $type = null) {
     } else {
         curl_setopt($ch, CURLOPT_USERPWD, "$apiuser:$apipass");
     }
+    if ( strcasecmp( $apiproto, 'https' ) == 0 ) {
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $apisslverify);
+    }
     curl_setopt($ch, CURLOPT_URL, $url); 
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
     if ($opts) {


### PR DESCRIPTION
The VERIFYPEER curl-option was only set for the initial connect to find out the auth-method while in auto-mode.
To connect to a selfsigned-cert it's needed in the main api-request.