### PR TITLE
Docker: Move configuration to runtime rather than build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,6 @@ MAINTAINER Yury Evtikhov <yury@evtikhov.info>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-#
-# Please set the following variables before building:
-#
-ENV PDNSAPIPWD mypowerdnsapipassword
-ENV PDNSAPIIP 192.168.1.2
-ENV PDNSAPIPORT 8081
-
 # Update and Upgrade system
 RUN apt-get -y update && \
     apt-get -y install curl git-core php5-cli php5-curl php5-json php5-sqlite && \
@@ -21,17 +14,15 @@ RUN apt-get -y update && \
 RUN mkdir /app
 RUN git clone --recursive https://github.com/tuxis-ie/nsedit.git /app/nsedit
 RUN cp /app/nsedit/includes/config.inc.php-dist /app/nsedit/includes/config.inc.php
-RUN sed "s/\$apipass = ''/\$apipass = '$PDNSAPIPWD'/" -i /app/nsedit/includes/config.inc.php && \
-    sed "s/\$apiip   = ''/\$apiip = '$PDNSAPIIP'/" -i /app/nsedit/includes/config.inc.php && \
-    sed "s/\$apiport = '8081'/\$apiport = '$PDNSAPIPORT'/" -i /app/nsedit/includes/config.inc.php && \
-    sed "s/\$authdb  = \"\.\.\/etc\/pdns\.users\.sqlite3\"/\$authdb  = \"\/app\/pdns\.users\.sqlite3\"/" -i /app/nsedit/includes/config.inc.php
+COPY docker-entrypoint.sh /app/nsedit/docker-entrypoint.sh
+RUN chmod +x /app/nsedit/docker-entrypoint.sh
 
 # Define working directory.
 VOLUME /app/nsedit
 WORKDIR /app/nsedit
 EXPOSE 8080
 
-ENTRYPOINT ["/usr/bin/php", "-S", "0.0.0.0:8080"]
+CMD ["sh", "-c", "/app/nsedit/docker-entrypoint.sh"]
 
 #
 # Usage:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+[ -z "$PDNSAPIIP" ] && echo "Set PDNSAPIIP to your PowerDNS API IP/Hostname" && exit 1;
+[ -z "$PDNSAPIPWD" ] && echo "Set PDNSAPIPWD to your PowerDNS API Password" && exit 1;
+
+sed "s/\$apipass = ''/\$apipass = '$PDNSAPIPWD'/" -i /app/nsedit/includes/config.inc.php
+sed "s/\$apiip   = ''/\$apiip = '$PDNSAPIIP'/" -i /app/nsedit/includes/config.inc.php
+if [[ $PDNSAPIPORT && ${PDNSAPIPORT-x} ]]
+then
+    sed "s/\$apiport = '8081'/\$apiport = '$PDNSAPIPORT'/" -i /app/nsedit/includes/config.inc.php
+fi
+sed "s/\$authdb  = \"\.\.\/etc\/pdns\.users\.sqlite3\"/\$authdb  = \"\/app\/pdns\.users\.sqlite3\"/" -i /app/nsedit/includes/config.inc.php
+
+exec /usr/bin/php -S 0.0.0.0:8080


### PR DESCRIPTION
I wanted to deploy this to my docker environment however I don't want our credentials baked in to the image, so I moved the sed lines out from the Dockerfile into an entrypoint script to allow you to set the three configuration variables (IP/Password/Port) at runtime.

I also made it such that the port is optional, and only changes `config.inc.php` if the environment variable is set.