### PR TITLE
Fix api calls

### DIFF
--- a/includes/class/ApiHandler.php
+++ b/includes/class/ApiHandler.php
@@ -32,13 +32,7 @@ class ApiHandler {
         $tmp->url = '/api/v1/servers/localhost';
         $tmp->go();
         
-        $v = intval(substr($tmp->json["version"],0,1));
-        if ($v == 4) {
-            $this->apiurl = $tmp->json["url"];
-        } else {
-            throw new Exception("Unsupported API version");
-        }
-
+        $this->apiurl = $tmp->json["url"];
     }
 
     private function curlopts() {

--- a/includes/class/PdnsApi.php
+++ b/includes/class/PdnsApi.php
@@ -64,7 +64,7 @@ class PdnsAPI {
 
         if (!isset($zone['serial']) or gettype($zone['serial']) != 'integer') {
             $api->method = 'POST';
-            $api->url = '/localhost/zones';
+            $api->url = '/zones';
             $api->content = json_encode($zonedata);
             $api->call();
 


### PR DESCRIPTION
Fixes API calls to create zones. Also, ignore issues with versions and API. pdns < 4.0 is EOL and thus we assume a valid API-endpoint.

Tested with 4.0.3 and 4.1.3 and master.

Closes #178 

Relates to #179 #162 #146 