### PR TITLE
INCEPTION-INCREMENT is not a valid option for soa_edit_api

### DIFF
--- a/includes/config.inc.php-dist
+++ b/includes/config.inc.php-dist
@@ -53,7 +53,7 @@ $templates[] = array(
 */
 
 $defaults['soa_edit']    = 'INCEPTION-INCREMENT';
-$defaults['soa_edit_api'] = 'INCEPTION-INCREMENT';
+$defaults['soa_edit_api'] = 'DEFAULT';
 $defaults['defaulttype'] = 'Master';                    # Choose between 'Native' or 'Master'
 $defaults['ns'][0] = 'unconfigured.primaryns.';         # The value of the first NS-record
 $defaults['ns'][1] = 'unconfigured.secondaryns.';       # The value of the second NS-record


### PR DESCRIPTION
INCEPTION-INCREMENT is not a valid option for soa_edit_api, see:
https://doc.powerdns.com/authoritative/domainmetadata.html#soa-edit-api

-> "These rules are the same as the SOA-EDIT-DNSUPDATE rules."
--> https://doc.powerdns.com/authoritative/dnsupdate.html#dnsupdate-soa-serial-updates
---> There is no "INCEPTION-INCREMENT" Setting.

Since 4.2 this is more strictly checked by PowerDNS:
https://github.com/PowerDNS/pdns/commit/636301b9f15aa5eecab4282258e85503b7ea4dcf#diff-fcc782f1cdc22f79be390c5d65da9050

Before this, it would simply use the DEFAULT option, now it logs an error and doesn't increase the Serial:  "SOA-EDIT-API/DNSUPDATE type 'INCEPTION-INCREMENT' for zone myzone.com is unknown."

Setting this to DEFAULT will therefore, as PowerDNS simply fell back to DEFAULT before, keep expected behaviour.