### PR TITLE
WIP: Place brackets around the hostname

### DIFF
--- a/includes/class/ApiHandler.php
+++ b/includes/class/ApiHandler.php
@@ -60,7 +60,7 @@ class ApiHandler {
     }
 
     private function baseurl() {
-        return $this->proto.'://'.$this->hostname.':'.$this->port.$this->apiurl;
+        return $this->proto.'://['.$this->hostname.']:'.$this->port.$this->apiurl;
     }
 
     private function go() {


### PR DESCRIPTION
When setting `$apiip` to an IPv6 address, requests to the PowerDNS API fail with cURL error 0 and an empty `curl_error`. This is because cURL doesn't understand we're working with an IPv6 address. This should be fixed by placing brackets around the address.

This PR is not finished. AFAIK, we don't have to check the address family, because placing brackets around an IPv4 address works. However, we still have no know whether we're dealing with a hostname or not.