### PR TITLE
Add missing return to Comment::export

### DIFF
--- a/includes/class/Zone.php
+++ b/includes/class/Zone.php
@@ -368,6 +368,8 @@ class Comment {
         $ret['content'] = $this->content;
         $ret['account'] = $this->account;
         $ret['modified_at'] = $this->modified_at;
+
+        return $ret;
     }
 }
 


### PR DESCRIPTION
Without this return, RRSet::exportComments returns an array of `null`, which causes PowerDNS to return `Key 'content' not present or not a String`.