### PR TITLE
Make cloning admin-only, check zones returned by formzonelist

### DIFF
--- a/index.php
+++ b/index.php
@@ -181,8 +181,10 @@ if ($blocklogin === TRUE) {
     }
     ?>
     <div id="zones">
-        <?php if (is_adminuser() or $allowzoneadd === TRUE) { ?>
+        <?php if ($allowzoneadd === TRUE) { ?>
         <div style="display: none;" id="ImportZone"></div>
+        <?php } ?>
+        <?php if (is_adminuser()) { ?>
         <div style="display: none;" id="CloneZone"></div>
         <?php } ?>
         <div class="tables" id="MasterZones">
@@ -503,7 +505,7 @@ $(document).ready(function () {
             hoverAnimationDuration: 60,
             hoverAnimationEasing: undefined,
             items: [
-                <?php if (is_adminuser() or $allowzoneadd === TRUE) { ?>
+                <?php if ($allowzoneadd === TRUE) { ?>
                 {
                     icon: 'jtable/lib/themes/metro/add.png',
                     text: 'Import a new zone',
@@ -511,6 +513,8 @@ $(document).ready(function () {
                         $('#ImportZone').jtable('showCreateForm');
                     }
                 },
+                <?php } ?>
+                <?php if (is_adminuser()) { ?>
                 {
                     icon: 'jtable/lib/themes/metro/add.png',
                     text: 'Clone a zone',
@@ -887,7 +891,6 @@ $(document).ready(function () {
         }
 
     });
-
     $('#CloneZone').jtable({
         title: 'Clone zone',
         actions: {

--- a/zones.php
+++ b/zones.php
@@ -546,6 +546,8 @@ case "formzonelist":
     usort($zones, "zone_compare");
     $ret = array();
     foreach ($zones as $zone) {
+        if (!check_account($zone))
+            continue;
         if ($zone['kind'] == 'Slave')
             continue;
         array_push($ret, array(


### PR DESCRIPTION
Cloning was meant to be an admin-only functionality. However, this was not fully implemented: when `allowzoneadd = true`, the user could clone zones, even when not an admin. This is not necessarily a problem. But in this case, it is. Because the endpoint that is used to get zones to clone (`formzonelist`), did not check whether those zones belong to the current user. In other words: when `allowzoneadd = true` and the user is not an admin, that user is able to see *all zones* under 'Clone a zone' button -> 'Source domain' dropdown.

This commit fixes that, by letting `formzonelist` return only zones belonging to the user, and showing the 'Clone a zone' button only when the user is an admin.