### PR TITLE
Add support to load templates from json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 includes/config.inc.php
 nsedit.sublime*
 etc
+templates.d/*.json

--- a/includes/misc.inc.php
+++ b/includes/misc.inc.php
@@ -253,6 +253,27 @@ function jtable_respond($records, $method = 'multiple', $msg = 'Undefined errorm
 function user_template_list() {
     global $templates;
 
+    if (is_dir("templates.d")) {
+        if ($templdir=opendir("templates.d")) {
+            while ($entry = readdir($templdir)) {
+                if (!str_ends_with($entry, ".json")) {
+                    continue;
+                }
+                $f=file_get_contents("templates.d/$entry");
+                if ($f === false) {
+                    error_log("Error reading file templates.d/$entry", 0);
+                    continue;
+                }
+                $t = json_decode($f, true);
+                if ($t === null) {
+                    error_log("Error decoding templates.d/$entry", 0);
+                    continue;
+                }
+                array_push($templates, $t);
+            }
+        }
+    }
+
     $templatelist = array();
     foreach ($templates as $template) {
         if (is_adminuser()

--- a/templates.d/template.json.example
+++ b/templates.d/template.json.example
@@ -1,0 +1,28 @@
+{
+    "name": "Example Template",
+    "owner": "public",
+    "records": [
+        {
+            "name": "",
+            "type": "NS",
+            "content": "ns1.example.com.",
+            "label": "ns1"
+        },
+        {
+            "name": "",
+            "type": "NS",
+            "content": "ns2.example.com.",
+            "label": "ns2"
+        },
+        {
+            "name": "example-txt",
+            "type": "TXT",
+            "content": "This is an example txt record"
+        },
+        {
+            "name": "localhost",
+            "type": "A",
+            "content": "127.0.0.1"
+        }
+    ]
+}


### PR DESCRIPTION
Our config.inc.php was getting a bit long and unreadable, so i added support for loading templates from .json files. 

For existing installs this changes nothing as templates loaded from files are appended to the existing $templates before the "is this user allowed to use this template" check.

If an error is encountered loading a template a message is logged and the template is skipped.